### PR TITLE
Fix for error when installing with Powershell on Windows 10

### DIFF
--- a/src/dotnet-commands/install.ps1
+++ b/src/dotnet-commands/install.ps1
@@ -1,5 +1,5 @@
 $ErrorActionPreference = "Stop"
-$releases = Invoke-WebRequest https://github.com/Lambda3/dotnet-commands/releases.atom
+$releases = Invoke-WebRequest -UseBasicParsing https://github.com/Lambda3/dotnet-commands/releases.atom
 $uri="https://github.com/Lambda3/dotnet-commands/releases/download/$($([xml]$releases.Content).feed.entry[0].title)/dotnet-commands.zip"
 $outFile=[System.IO.Path]::GetTempFileName()
 Invoke-WebRequest -uri $uri -OutFile $outFile


### PR DESCRIPTION
When I tried to run the install script I got the following error

``` powershell
> &{$wc=New-Object System.Net.WebClient;$wc.Proxy=[System.Net.WebRequest]::DefaultWebProxy;$wc.Proxy.Credentials=[System.Net.CredentialCache]::DefaultNetworkCredentials;Invoke-Expression($wc.DownloadString('https://raw.githubusercontent.com/Lambda3/dotnet-commands/master/src/dotnet-commands/install.ps1'))}

Invoke-WebRequest : The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing
parameter and try again.
At line:2 char:13
+ $releases = Invoke-WebRequest https://github.com/Lambda3/dotnet-comma ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotImplemented: (:) [Invoke-WebRequest], NotSupportedException
    + FullyQualifiedErrorId : WebCmdletIEDomNotSupportedException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
```

By reading the error I found out it's because I never opened Internet Explorer. There was little reason to, but now I got this error.

I fixed this by simply adding the `UseBasicParsing` flag as suggested by the error message.
